### PR TITLE
[bug][Task.kt / TaskRuntimeInfo.kt] :

### DIFF
--- a/anchors/src/main/java/com/effective/android/anchors/Task.kt
+++ b/anchors/src/main/java/com/effective/android/anchors/Task.kt
@@ -91,15 +91,13 @@ abstract class Task @JvmOverloads constructor(//mId,唯一存在
         }
     }
 
-    val dependTaskName: Set<String>
-        get() {
-            val result: MutableSet<String> = HashSet()
-            for (task in dependTasks) {
-                result.add(task.id)
-            }
-            return result
+    fun getDependTaskName(): Set<String> {
+        val result: MutableSet<String> = HashSet()
+        for (task in dependTasks) {
+            result.add(task.id)
         }
-
+        return result
+    }
 
     fun removeDepend(originTask: Task?) {
         if (dependTasks.contains(originTask)) {

--- a/anchors/src/main/java/com/effective/android/anchors/TaskRuntimeInfo.kt
+++ b/anchors/src/main/java/com/effective/android/anchors/TaskRuntimeInfo.kt
@@ -11,6 +11,7 @@ class TaskRuntimeInfo(var task: Task) {
 
     val stateTime: SparseArray<Long>
     var isAnchor = false
+    val dependencies: Set<String>
     var threadName: String = ""
 
     /**
@@ -27,9 +28,6 @@ class TaskRuntimeInfo(var task: Task) {
         stateTime.put(state, time)
     }
 
-    val dependencies: Set<String>
-        get() = task.dependTaskName
-
     fun isTaskInfo(task: Task?): Boolean {
         return task != null && this.task === task
     }
@@ -42,11 +40,11 @@ class TaskRuntimeInfo(var task: Task) {
     }
 
     init {
-        this.task = task
         threadName = ""
         stateTime = SparseArray()
         setStateTime(TaskState.START, DEFAULT_TIME)
         setStateTime(TaskState.RUNNING, DEFAULT_TIME)
         setStateTime(TaskState.FINISHED, DEFAULT_TIME)
+        dependencies = task.getDependTaskName()
     }
 }


### PR DESCRIPTION
解决 'TASK_DETAIL' 标签下 “依赖任务” 永远为空的问题，

原因是等到该任务被运行的时刻才去获取其依赖已经晚了
（上层依赖任务运行完毕将会从当前任务的依赖列表中移除）。

解决方式，在生成任务运行TaskRuntimeInfo信息的时刻，就将任务的依赖关系存入（此时依赖关系已经稳定）。